### PR TITLE
feat: FindEndpointSlice() helper that finds the endpoint slice for a given APIExport and use it across codebase

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -16,6 +17,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -25,6 +27,7 @@ import (
 
 	v1alpha1 "go.opendefense.cloud/dependency-controller/api/v1alpha1"
 	"go.opendefense.cloud/dependency-controller/internal/controller"
+	"go.opendefense.cloud/dependency-controller/internal/kcp"
 )
 
 var scheme = runtime.NewScheme()
@@ -64,8 +67,22 @@ func main() {
 		baseCfg.Host = kcpBaseHost
 	}
 
+	// Resolve the APIExportEndpointSlice name for the dep-ctrl's APIExport.
+	// The slice name is not necessarily the same as the APIExport name.
+	directClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create client for endpoint slice discovery")
+		os.Exit(1)
+	}
+
+	ess, err := kcp.FindEndpointSlice(context.Background(), directClient, apiExportName)
+	if err != nil {
+		setupLog.Error(err, "unable to find APIExportEndpointSlice", "apiExport", apiExportName)
+		os.Exit(1)
+	}
+
 	// Create apiexport provider for the dependency-controller's own APIExport.
-	depCtrlProvider, err := apiexport.New(cfg, apiExportName, apiexport.Options{
+	depCtrlProvider, err := apiexport.New(cfg, ess.Name, apiexport.Options{
 		Scheme: scheme,
 	})
 	if err != nil {

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -17,6 +17,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -26,6 +27,7 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	v1alpha1 "go.opendefense.cloud/dependency-controller/api/v1alpha1"
+	"go.opendefense.cloud/dependency-controller/internal/kcp"
 	"go.opendefense.cloud/dependency-controller/internal/webhook"
 )
 
@@ -66,8 +68,21 @@ func main() {
 		baseCfg.Host = kcpBaseHost
 	}
 
+	// Resolve the APIExportEndpointSlice name for the dep-ctrl's APIExport.
+	directClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create client for endpoint slice discovery")
+		os.Exit(1)
+	}
+
+	ess, err := kcp.FindEndpointSlice(context.Background(), directClient, apiExportName)
+	if err != nil {
+		setupLog.Error(err, "unable to find APIExportEndpointSlice", "apiExport", apiExportName)
+		os.Exit(1)
+	}
+
 	// Create apiexport provider for the dependency-controller's own APIExport.
-	depCtrlProvider, err := apiexport.New(cfg, apiExportName, apiexport.Options{
+	depCtrlProvider, err := apiexport.New(cfg, ess.Name, apiexport.Options{
 		Scheme: scheme,
 	})
 	if err != nil {

--- a/internal/controller/dependencyrule_controller.go
+++ b/internal/controller/dependencyrule_controller.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/kcp-dev/logicalcluster/v3"
-	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -21,6 +20,7 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	v1alpha1 "go.opendefense.cloud/dependency-controller/api/v1alpha1"
+	"go.opendefense.cloud/dependency-controller/internal/kcp"
 )
 
 // DependencyRuleReconciler watches DependencyRule objects across provider workspaces
@@ -74,15 +74,19 @@ func (r *DependencyRuleReconciler) ensureInitialized(ctx context.Context) error 
 		return fmt.Errorf("creating client for VW URL discovery: %w", err)
 	}
 
-	var ess apisv1alpha1.APIExportEndpointSlice
-	if err := directClient.Get(ctx, client.ObjectKey{Name: r.APIExportName}, &ess); err != nil {
-		return fmt.Errorf("getting APIExportEndpointSlice %s: %w", r.APIExportName, err)
+	ess, err := kcp.FindEndpointSlice(ctx, directClient, r.APIExportName)
+	if err != nil {
+		return fmt.Errorf("resolving APIExportEndpointSlice for %s: %w", r.APIExportName, err)
 	}
 
 	if len(ess.Status.APIExportEndpoints) == 0 {
-		return fmt.Errorf("APIExportEndpointSlice %s has no endpoints", r.APIExportName)
+		return fmt.Errorf("APIExportEndpointSlice %s has no endpoints", ess.Name)
 	}
 
+	// TODO: The VW URL is cached for the lifetime of the process. If the URL
+	// changes (e.g., kcp shard topology change), webhook installation will fail
+	// until the pod is restarted. Consider watching the APIExportEndpointSlice
+	// to re-discover the URL on changes.
 	vwURL := ess.Status.APIExportEndpoints[0].URL
 	r.vwBaseCfg = rest.CopyConfig(localCfg)
 	r.vwBaseCfg.Host = vwURL

--- a/internal/kcp/endpointslice.go
+++ b/internal/kcp/endpointslice.go
@@ -1,0 +1,31 @@
+// Copyright 2026 BWI GmbH and Dependency Controller contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package kcp
+
+import (
+	"context"
+	"fmt"
+
+	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FindEndpointSlice finds the APIExportEndpointSlice whose spec.export.name
+// matches the given APIExport name. The slice name is not guaranteed to match
+// the APIExport name — service providers can create custom slices with
+// different names.
+func FindEndpointSlice(ctx context.Context, c client.Reader, apiExportName string) (*apisv1alpha1.APIExportEndpointSlice, error) {
+	var list apisv1alpha1.APIExportEndpointSliceList
+	if err := c.List(ctx, &list); err != nil {
+		return nil, fmt.Errorf("listing APIExportEndpointSlices: %w", err)
+	}
+
+	for i := range list.Items {
+		if list.Items[i].Spec.APIExport.Name == apiExportName {
+			return &list.Items[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("no APIExportEndpointSlice found for APIExport %q", apiExportName)
+}

--- a/internal/webhook/rule_cache_manager.go
+++ b/internal/webhook/rule_cache_manager.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/kcp-dev/multicluster-provider/apiexport"
-	apisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,6 +25,7 @@ import (
 
 	v1alpha1 "go.opendefense.cloud/dependency-controller/api/v1alpha1"
 	"go.opendefense.cloud/dependency-controller/internal/fieldpath"
+	"go.opendefense.cloud/dependency-controller/internal/kcp"
 )
 
 // RuleCacheManager reconciles DependencyRule objects and manages a dedicated
@@ -98,13 +98,13 @@ func (m *RuleCacheManager) virtualWorkspaceClient(ctx context.Context) (client.C
 		return nil, fmt.Errorf("creating direct client: %w", err)
 	}
 
-	var ess apisv1alpha1.APIExportEndpointSlice
-	if err := directClient.Get(ctx, client.ObjectKey{Name: m.APIExportName}, &ess); err != nil {
-		return nil, fmt.Errorf("getting APIExportEndpointSlice %s: %w", m.APIExportName, err)
+	ess, err := kcp.FindEndpointSlice(ctx, directClient, m.APIExportName)
+	if err != nil {
+		return nil, fmt.Errorf("resolving APIExportEndpointSlice for %s: %w", m.APIExportName, err)
 	}
 
 	if len(ess.Status.APIExportEndpoints) == 0 {
-		return nil, fmt.Errorf("APIExportEndpointSlice %s has no endpoints", m.APIExportName)
+		return nil, fmt.Errorf("APIExportEndpointSlice %s has no endpoints", ess.Name)
 	}
 
 	vwURL := ess.Status.APIExportEndpoints[0].URL
@@ -259,7 +259,18 @@ func (m *RuleCacheManager) startProviderManager(ctx context.Context, clusterName
 	cfg := rest.CopyConfig(m.BaseConfig)
 	cfg.Host += logicalcluster.NewPath(clusterName).RequestPath()
 
-	provider, err := apiexport.New(cfg, apiExportName, apiexport.Options{
+	// Resolve the APIExportEndpointSlice name — it may differ from the APIExport name.
+	wsClient, err := client.New(cfg, client.Options{Scheme: m.Scheme})
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating client for endpoint slice discovery: %w", err)
+	}
+
+	ess, err := kcp.FindEndpointSlice(ctx, wsClient, apiExportName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving APIExportEndpointSlice for %s: %w", apiExportName, err)
+	}
+
+	provider, err := apiexport.New(cfg, ess.Name, apiexport.Options{
 		Scheme: m.Scheme,
 	})
 	if err != nil {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

Closes #23