### PR TITLE
chore: cleaner cluster name handling. ensureWebhooks now builds map[string]string of workspace path to cluster name - no more deep-copy and field mutation.

### DIFF
--- a/internal/controller/dependencyrule_controller.go
+++ b/internal/controller/dependencyrule_controller.go
@@ -148,20 +148,25 @@ func (r *DependencyRuleReconciler) Reconcile(ctx context.Context, req mcreconcil
 
 // ensureWebhooks installs webhooks in dependency provider workspaces via the VW.
 func (r *DependencyRuleReconciler) ensureWebhooks(ctx context.Context, ruleKey string, rule *v1alpha1.DependencyRule) error {
-	// Replace workspace paths with logical cluster names for the installer.
-	resolvedRule := rule.DeepCopy()
-	for i := range resolvedRule.Spec.Dependencies {
-		wsPath := resolvedRule.Spec.Dependencies[i].APIExportRef.Path
+	// Build a mapping from workspace path to logical cluster name.
+	clusterNames := make(map[string]string, len(rule.Spec.Dependencies))
+	for _, dep := range rule.Spec.Dependencies {
+		wsPath := dep.APIExportRef.Path
+		if _, ok := clusterNames[wsPath]; ok {
+			continue
+		}
+
 		clusterName, err := r.wsResolver.resolve(wsPath)
 		if err != nil {
 			return fmt.Errorf("resolving %s: %w", wsPath, err)
 		}
-		resolvedRule.Spec.Dependencies[i].APIExportRef.Path = clusterName
+
+		clusterNames[wsPath] = clusterName
 	}
 
 	r.WebhookInstaller.BaseConfig = r.vwBaseCfg
 
-	return r.WebhookInstaller.EnsureWebhooks(ctx, ruleKey, resolvedRule)
+	return r.WebhookInstaller.EnsureWebhooks(ctx, ruleKey, rule, clusterNames)
 }
 
 // collectWorkspacePaths extracts dependency workspace paths referenced in a DependencyRule.

--- a/internal/controller/webhook_installer.go
+++ b/internal/controller/webhook_installer.go
@@ -66,17 +66,19 @@ func NewWebhookInstaller(baseCfg *rest.Config, webhookURL string, caBundle []byt
 }
 
 // EnsureWebhooks installs or updates ValidatingWebhookConfigurations for all
-// dependency targets in the given rule.
-func (w *WebhookInstaller) EnsureWebhooks(ctx context.Context, ruleKey string, rule *v1alpha1.DependencyRule) error {
-	// Group targets by provider workspace so we do one update per workspace.
-	byWorkspace := make(map[string][]v1alpha1.DependencyTarget)
+// dependency targets in the given rule. The clusterNames map translates
+// workspace paths (from APIExportRef.Path) to logical cluster names used
+// to connect via the virtual workspace.
+func (w *WebhookInstaller) EnsureWebhooks(ctx context.Context, ruleKey string, rule *v1alpha1.DependencyRule, clusterNames map[string]string) error {
+	// Group targets by logical cluster name so we do one update per workspace.
+	byCluster := make(map[string][]v1alpha1.DependencyTarget)
 	for _, dep := range rule.Spec.Dependencies {
-		wsPath := dep.APIExportRef.Path
-		byWorkspace[wsPath] = append(byWorkspace[wsPath], dep)
+		clusterName := clusterNames[dep.APIExportRef.Path]
+		byCluster[clusterName] = append(byCluster[clusterName], dep)
 	}
 
-	for wsPath, deps := range byWorkspace {
-		if err := w.ensureWebhookForWorkspace(ctx, ruleKey, wsPath, deps); err != nil {
+	for clusterName, deps := range byCluster {
+		if err := w.ensureWebhookForWorkspace(ctx, ruleKey, clusterName, deps); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

Closes #24