### PR TITLE
Pin base image digests + auto-update via Renovate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b AS builder
 
 WORKDIR /workspace
 RUN go env -w GOMODCACHE=/root/.cache/go-build
@@ -25,20 +25,20 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o bin/dependency-webhook ./cmd/webhook/
 
-FROM gcr.io/distroless/static:nonroot AS controller
+FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39 AS controller
 WORKDIR /
 COPY --from=controller-builder /workspace/bin/dependency-controller .
 USER 65532:65532
 ENTRYPOINT ["/dependency-controller"]
 
-FROM gcr.io/distroless/static:nonroot AS webhook
+FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39 AS webhook
 WORKDIR /
 COPY --from=webhook-builder /workspace/bin/dependency-webhook .
 USER 65532:65532
 ENTRYPOINT ["/dependency-webhook"]
 
 # Combined image with both binaries (used by e2e tests and single-image deployments).
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
 WORKDIR /
 COPY --from=controller-builder /workspace/bin/dependency-controller .
 COPY --from=webhook-builder /workspace/bin/dependency-webhook .

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests", "docker:pinDigests"],
   "minimumReleaseAge": "1 day",
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Why

OSSF Scorecard flagged `Pinned-Dependencies` (Medium, normalized to 6/10) because base images are tag-only. Tags are mutable — a republished tag silently changes binary contents and is a supply-chain vector. Digest pinning closes that; the Renovate preset keeps the digests fresh.

## What

- **Dockerfile** — `@sha256:...` on the 4 external `FROM` lines (1, 28, 34, 41). Lines 18/23 are local stage refs, nothing to pin.
- **renovate.json** — added `docker:pinDigests` so Renovate auto-PRs digest updates when tags get republished.

Digests verified via `crane digest` against the live multi-arch indexes.

## Test plan

- [x] `docker buildx build --check --target controller .` passes
- [x] `jq` confirms `renovate.json` is valid
- [ ] Next Scorecard run shows `Pinned-Dependencies` ≥ 9/10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configurations for improved build reproducibility and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendefensecloud/dependency-controller/pull/66)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->