### PR TITLE
Dockerfile digest pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3@sha256:313faae491b410a35402c05d35e7518ae99103d957308e940e1ae2cfa0aac29b AS builder
 
 WORKDIR /workspace
 RUN go env -w GOMODCACHE=/root/.cache/go-build
@@ -25,20 +25,20 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o bin/dependency-webhook ./cmd/webhook/
 
-FROM gcr.io/distroless/static:nonroot AS controller
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240 AS controller
 WORKDIR /
 COPY --from=controller-builder /workspace/bin/dependency-controller .
 USER 65532:65532
 ENTRYPOINT ["/dependency-controller"]
 
-FROM gcr.io/distroless/static:nonroot AS webhook
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240 AS webhook
 WORKDIR /
 COPY --from=webhook-builder /workspace/bin/dependency-webhook .
 USER 65532:65532
 ENTRYPOINT ["/dependency-webhook"]
 
 # Combined image with both binaries (used by e2e tests and single-image deployments).
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 WORKDIR /
 COPY --from=controller-builder /workspace/bin/dependency-controller .
 COPY --from=webhook-builder /workspace/bin/dependency-webhook .

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests", "docker:pinDigests"],
   "minimumReleaseAge": "1 day",
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
@@ -22,10 +22,6 @@
       "groupName": "golang version sync",
       "groupSlug": "go-version"
     },
-    {
-      "matchManagers": ["dockerfile"],
-      "pinDigests": true
-    }
   ],
   "customManagers": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,10 @@
       "matchPackageNames": ["go", "golang"],
       "groupName": "golang version sync",
       "groupSlug": "go-version"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "pinDigests": true
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Closes #70 

### Summary

- Pins all four external FROM references in the multi-stage Dockerfile to their SHA256 manifest-list digests (tag@sha256:... form), eliminating the risk of tag mutation substituting a different image layer silently
- Adds a dockerfile packageRule to renovate.json so Renovate keeps the pinned digests up to date via PRs automatically

**Note**
Pls Note that the Digests pin to the Index of the Multiarch Images. So you can verify it via: 

```
docker buildx imagetools inspect gcr.io/distroless/static:nonroot
docker buildx imagetools inspect golang:1.26.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned container base images to specific digests across all build and runtime stages.
  * Updated dependency automation configuration to enforce automated digest pinning for container images in future updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendefensecloud/dependency-controller/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->