### PR TITLE
Add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,11 @@
 
 Due to the nature of the Open Defense Cloud products the maintainers take security very seriously.
 
+## Supported Versions
+
+The dependency-controller is currently in **alpha** state. As such, there are no backported security patches or maintenance releases for previous versions.
+Security fixes are released "fail forward" only: a fix ships in the next new version, and users are expected to upgrade to that version to receive it.
+
 ## Reporting a Vulnerability
 
 Open Defense Cloud uses GitHub to allow submission of private security reports. Please report any security finding via

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+Due to the nature of the Open Defense Cloud products the maintainers take security very seriously.
+
+## Reporting a Vulnerability
+
+Open Defense Cloud uses GitHub to allow submission of private security reports. Please report any security finding via
+[this link](https://github.com/opendefensecloud/dependency-controller/security/advisories/new).
+Maintainers will triage your report as soon as possible and get in touch with you via your report in case they have more questions.
+
+As a security researcher, please report vulnerabilities to the OpenDefenseCloud in a [coordinated vulnerability disclosure](https://cheatsheetseries.owasp.org/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.html)
+fashion. In return, maintainers pledge to engage in good faith and collaborate with security researchers to address and publish vulnerabilities found in the dependency-controller as soon as possible.
+
+Please understand that the maintainers also do not accept results of dependency scanners without proof that the detected CVE / vulnerability can be used against the dependency-controller purpose.
+
+## Security Advisories
+
+Advisories are managed through GitHub. Public disclosure of vulnerabilities happens through GitHub.
+Please visit [Security Advisories](https://github.com/opendefensecloud/dependency-controller/security/advisories) to review security bulletins published by the maintainers.


### PR DESCRIPTION
Same policy as in the quota-controller. And also enabled private vulnerability reporting. 

Closes #56 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy page with guidance for reporting vulnerabilities.
  * Clarified how security issues are handled, including coordinated disclosure and public advisory process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->