### PR TITLE
add helm webhook image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ APIGEN ?= $(LOCALGOBIN)/apigen
 KCP ?= $(LOCALBIN)/kcp
 KCP_VERSION ?= 0.30.0
 
-IMG_REGISTRY ?= ghcr.io/opendefense
+IMG_REGISTRY ?= ghcr.io/opendefensecloud
 IMG_TAG ?= latest
 CONTROLLER_IMG ?= $(IMG_REGISTRY)/dependency-controller:$(IMG_TAG)
 WEBHOOK_IMG ?= $(IMG_REGISTRY)/dependency-webhook:$(IMG_TAG)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ KCP_VERSION ?= 0.30.0
 IMG_REGISTRY ?= ghcr.io/opendefense
 IMG_TAG ?= latest
 CONTROLLER_IMG ?= $(IMG_REGISTRY)/dependency-controller:$(IMG_TAG)
-WEBHOOK_IMG ?= $(IMG_REGISTRY)/dependency-controller:$(IMG_TAG)
+WEBHOOK_IMG ?= $(IMG_REGISTRY)/dependency-webhook:$(IMG_TAG)
 
 TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
 DEV_TAG ?= dev.$(TIMESTAMP)

--- a/charts/dependency-controller/files/dependencies.opendefense.cloud_dependencyrules.yaml
+++ b/charts/dependency-controller/files/dependencies.opendefense.cloud_dependencyrules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: dependencyrules.dependencies.opendefense.cloud
 spec:
   group: dependencies.opendefense.cloud

--- a/charts/dependency-controller/templates/_helpers.tpl
+++ b/charts/dependency-controller/templates/_helpers.tpl
@@ -18,7 +18,7 @@
 {{- define "dependency-controller.labels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{ include "dependency-controller.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.controller.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/dependency-controller/templates/_helpers.tpl
+++ b/charts/dependency-controller/templates/_helpers.tpl
@@ -18,7 +18,7 @@
 {{- define "dependency-controller.labels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{ include "dependency-controller.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.controller.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/dependency-controller/templates/deployment.yaml
+++ b/charts/dependency-controller/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ include "dependency-controller.serviceAccountName" . }}
       containers:
         - name: controller
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /dependency-controller

--- a/charts/dependency-controller/templates/webhook-deployment.yaml
+++ b/charts/dependency-controller/templates/webhook-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ include "dependency-controller.webhook.serviceAccountName" . }}
       containers:
         - name: webhook
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.webhook.image.repository }}:{{ .Values.webhook.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /dependency-webhook

--- a/charts/dependency-controller/values.yaml
+++ b/charts/dependency-controller/values.yaml
@@ -1,3 +1,7 @@
+# BREAKING CHANGE: the top-level image.repository and image.tag keys used in
+# chart versions <= 0.4.0 were removed. Set controller.image.repository/tag
+# for the controller image and webhook.image.repository/tag for the webhook
+# image instead — overrides of the old keys are silently ignored.
 image:
   pullPolicy: IfNotPresent
 

--- a/charts/dependency-controller/values.yaml
+++ b/charts/dependency-controller/values.yaml
@@ -1,6 +1,4 @@
 image:
-  repository: ghcr.io/opendefensecloud/dependency-controller
-  tag: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -14,6 +12,10 @@ kcpBaseHost: ""
 
 # Controller configuration.
 controller:
+  image:
+    repository: ghcr.io/opendefensecloud/dependency-controller
+    tag: ""
+
   replicas: 1
 
   # Secret containing a kubeconfig for connecting to kcp.
@@ -43,6 +45,10 @@ controller:
 
 # Webhook server configuration.
 webhook:
+  image:
+    repository: ghcr.io/opendefensecloud/dependency-webhook
+    tag: ""
+
   replicas: 1
 
   port: 9443

--- a/config/crds/dependencies.opendefense.cloud_dependencyrules.yaml
+++ b/config/crds/dependencies.opendefense.cloud_dependencyrules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: dependencyrules.dependencies.opendefense.cloud
 spec:
   group: dependencies.opendefense.cloud

--- a/flake.lock
+++ b/flake.lock
@@ -15,11 +15,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780041366,
-        "narHash": "sha256-I1iftykHs00f0+HI/TrMEhcxwOVHMNfG8GjkLnKgTtQ=",
+        "lastModified": 1781814153,
+        "narHash": "sha256-jbx068xJf5OwC6lR/JM33myb/+KnATU8HCK6AHJTVY8=",
         "owner": "opendefensecloud",
         "repo": "dev-kit",
-        "rev": "c53d2a15cd1b83f238c91f174bce003dfb12a71a",
+        "rev": "41370fd52f6889401ef79388e54e7e38bfbf112e",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779167584,
-        "narHash": "sha256-iAMW53zbWUrGtLjtq66Sqzbz803aT+IBPg+0l6mztE8=",
+        "lastModified": 1785145350,
+        "narHash": "sha256-yQc4uTBKM0yl/Xv66pW/5yaZuHd+Ava+GzEgrv4Aqzs=",
         "owner": "purpleclay",
         "repo": "go-overlay",
-        "rev": "1a7dd3c1e396d5d969da6f7a39bc6affd0847f1c",
+        "rev": "1c161331a7d94d356846870530adf4447715d2fc",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Add configurable webhook image to the helm chart as requested in https://github.com/opendefensecloud/dependency-controller/issues/104
With that given, global image config for controller needs to be moved to the controller section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected webhook image configuration so deployments use the dedicated webhook image.
  * Updated controller and webhook image settings to support independent repositories and tags.
  * Ensured controller version labels reflect the configured controller image tag.

* **Chores**
  * Updated generated resource metadata to the newer controller tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->